### PR TITLE
Add demo mode support with tests and CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Server settings
+PORT=3001
+
+# KuCoin API credentials (required for live trading)
+KUCOIN_API_KEY=your_api_key
+KUCOIN_API_SECRET=your_api_secret
+KUCOIN_API_PASSPHRASE=your_api_passphrase
+
+# Optional demo settings
+# Set DEMO_MODE=true to run with synthetic data and mock API responses.
+# No live orders will be sent when demo mode is enabled.
+DEMO_MODE=false
+# Disable recurring background intervals for testing purposes
+RUN_INTERVALS=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        env:
+          DEMO_MODE: 'true'
+          RUN_INTERVALS: 'false'
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.env
+.retry_queue.json
+positions.json
+retry_queue.json
+npm-debug.log*
+.DS_Store
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# KuCoin Perpetual Futures Dashboard v3.5.0
+# KuCoin Perpetual Futures Dashboard v3.5.1
 
 ## 🚀 V3.5 Enhancements
 
@@ -289,7 +289,13 @@ This software is for educational purposes. Cryptocurrency trading involves subst
 
 ## 📝 Version History
 
-### v3.5.0 (Current)
+### v3.5.1 (Current)
+- Demo mode with synthetic KuCoin data and mock trading client
+- Test-friendly startup controls and graceful shutdown improvements
+- Automated formula tests and GitHub Actions CI pipeline
+- Updated environment template and documentation for unified setup
+
+### v3.5.0
 - Fee-adjusted break-even calculation
 - Accurate liquidation price formula
 - Slippage buffer on stop orders
@@ -312,3 +318,34 @@ This software is for educational purposes. Cryptocurrency trading involves subst
 ### v3.4.0
 - Dollar-based position sizing
 - Leveraged P&L percentages
+
+---
+
+## 🧰 Local Development & Demo Mode
+
+1. Copy the environment template and configure credentials (or enable demo mode):
+   ```bash
+   cp .env.example .env
+   # add your KUCOIN_API_KEY, KUCOIN_API_SECRET, KUCOIN_API_PASSPHRASE
+   # or set DEMO_MODE=true to explore the dashboard with synthetic data
+   ```
+2. Install dependencies and start the server:
+   ```bash
+   npm install
+   npm start
+   ```
+   When `DEMO_MODE=true`, the server uses a mock KuCoin client, generates synthetic market data, and never sends live orders.
+3. Run the automated tests:
+   ```bash
+   npm test
+   ```
+   (Set `RUN_INTERVALS=false` in automation to skip background polling timers.)
+
+
+## ✅ Release Notes (v3.5.1)
+- Added demo mode with synthetic market data and mock KuCoin client for safe local exploration.
+- Added automated tests for trading math formulas (`node --test`).
+- Added GitHub Actions CI workflow to run tests on every push/PR.
+- Hardened server lifecycle: optional interval startup, graceful shutdown, and test-friendly exports.
+- Provided `.env.example` and updated README with unified setup instructions.
+

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <!--
-  KuCoin Futures Dashboard V3.5.0
+  KuCoin Futures Dashboard V3.5.1
   ENHANCEMENTS:
   - Fee-adjusted break-even calculation
   - Accurate liquidation price formula
@@ -1548,7 +1548,7 @@
     <div class="logo">
       <div class="logo-icon">KF</div>
       <span class="logo-text">KuCoin Futures</span>
-      <span class="version-badge">v3.5.0 • Fee-Adjusted ROI</span>
+      <span class="version-badge">v3.5.1 • Fee-Adjusted ROI</span>
     </div>
     
     <div class="header-stats">
@@ -1963,7 +1963,7 @@
 
   <script>
     // ========================================================================
-    // KUCOIN FUTURES DASHBOARD V3.5.0
+    // KUCOIN FUTURES DASHBOARD V3.5.1
     // ========================================================================
     class Dashboard {
       constructor() {
@@ -2009,7 +2009,7 @@
       init() {
         this.setupEventListeners();
         this.connect();
-        this.log('Dashboard V3.5.0 initializing...', 'info');
+        this.log('Dashboard V3.5.1 initializing...', 'info');
       }
 
       // ====================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kucoin-futures-dashboard",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kucoin-futures-dashboard",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "kucoin-futures-dashboard",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "KuCoin Perpetual Futures Semi-Automated Trading Dashboard with V3.5 Enhancements",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "node --watch server.js"
+    "dev": "node --watch server.js",
+    "test": "node --test"
   },
   "keywords": [
     "kucoin",

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# KuCoin Futures Dashboard V3.5.0 - Setup Script
+# KuCoin Futures Dashboard V3.5.1 - Setup Script
 
 echo "╔═══════════════════════════════════════════════════════════════╗"
-echo "║     KuCoin Futures Dashboard v3.5.0 Setup                     ║"
+echo "║     KuCoin Futures Dashboard v3.5.1 Setup                     ║"
 echo "╚═══════════════════════════════════════════════════════════════╝"
 echo ""
 

--- a/tests/tradeMath.test.js
+++ b/tests/tradeMath.test.js
@@ -1,0 +1,51 @@
+process.env.DEMO_MODE = 'true';
+process.env.RUN_INTERVALS = 'false';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { TradeMath } = require('../server');
+
+describe('TradeMath core formulas', () => {
+  test('calculates position sizing using account percentage and leverage', () => {
+    const marginUsed = TradeMath.calculateMarginUsed(10000, 0.5);
+    assert.strictEqual(marginUsed, 50);
+
+    const positionValue = TradeMath.calculatePositionValue(marginUsed, 10);
+    assert.strictEqual(positionValue, 500);
+  });
+
+  test('derives leveraged ROI from price change', () => {
+    const priceDiff = TradeMath.calculatePriceDiff('long', 100, 102);
+    const unrealized = TradeMath.calculateUnrealizedPnl(priceDiff, 2);
+    const roi = TradeMath.calculateLeveragedPnlPercent(unrealized, 50);
+    assert.strictEqual(unrealized, 4);
+    assert.strictEqual(roi, 8);
+  });
+
+  test('adds fee-adjusted break-even buffer', () => {
+    const breakEven = TradeMath.calculateFeeAdjustedBreakEven(0.0006, 0.0006, 10, 0.1);
+    assert.strictEqual(breakEven, 1.3);
+  });
+
+  test('computes ROI-based stop loss and take profit prices', () => {
+    const sl = TradeMath.calculateStopLossPrice('long', 100, 0.5, 10);
+    const tp = TradeMath.calculateTakeProfitPrice('long', 100, 2, 10);
+    assert.strictEqual(sl, 99.95);
+    assert.strictEqual(tp, 100.2);
+  });
+
+  test('calculates liquidation price with maintenance margin', () => {
+    const liq = TradeMath.calculateLiquidationPrice('long', 10000, 10, 0.5);
+    assert.strictEqual(Number(liq.toFixed(0)), 8995);
+  });
+
+  test('applies slippage buffer to stop orders', () => {
+    const adjusted = TradeMath.calculateSlippageAdjustedStop('long', 100, 0.02);
+    assert.strictEqual(adjusted, 99.98);
+  });
+
+  test('derives auto-leverage recommendation from ATR%', () => {
+    const leverage = TradeMath.calculateAutoLeverage(0.7, 1.5);
+    assert.strictEqual(leverage, 38);
+  });
+});


### PR DESCRIPTION
## Summary
- add demo-mode option with a mock KuCoin client, controllable background intervals, and a safer startup/shutdown flow
- publish setup collateral (.env.example, gitignore, updated README/release notes) and bump the app to v3.5.1
- add TradeMath unit tests and wire CI to run `npm test` in demo mode

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695241e3c6a4832a8735838aae1b647e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v3.5.1

* **New Features**
  * Demo mode with synthetic market data and mock trading capabilities for testing without live connections
  * Test-friendly startup controls and improved graceful shutdown

* **Tests**
  * Comprehensive automated formula tests for trading calculations
  * GitHub Actions CI pipeline for continuous integration

* **Documentation**
  * Updated environment setup guide and release documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->